### PR TITLE
Add support for Postgres 17

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,7 @@ env:
   REGISTRY: ghcr.io
   TEST_TAG: ${{ github.repository }}:test
   COMPOSE_FILE: ./docker-compose.test.yml
-  LATEST_TAG: 16-3.5
+  LATEST_TAG: 17-3.5
 
 jobs:
   build-and-push-image:
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [16, 15, 14, 13, 12]
+        postgres: [17, 16, 15, 14, 13, 12]
         postgis: ['3.5']
 
     env:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [17, 16, 15, 14, 13, 12]
+        postgres: [17, 16, 15, 14, 13]
         postgis: ['3.5']
 
     env:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Tag labels follow the pattern `X-Y.Z`, where `X` is the *major* Postgres version (starting from version 12) and `Y.Z` is the *major.minor* Postgis version.
 
-The `latest` tag currently corresponds to `16-3.5`.
+The `latest` tag currently corresponds to `17-3.5`.
 
 ## Usage
 

--- a/compose_example/docker-compose.yml
+++ b/compose_example/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
 
   postgres:
-    # image: ivanlonel/postgis-with-extensions:16-3.5
+    # image: ivanlonel/postgis-with-extensions:17-3.5
     build:
       context: . # Use image from Dockerfile in current dir
       args:
-        - BASE_IMAGE_TAG=16-3.5
+        - BASE_IMAGE_TAG=17-3.5
         - LOCALE=pt_BR
         - ENCODING=UTF-8
     command:


### PR DESCRIPTION
## Summary by Sourcery

Add support for Postgres 17 by updating Docker configurations, CI workflows, and documentation.

New Features:
- Add support for Postgres 17 in the Docker setup.

CI:
- Update CI workflow to include Postgres 17 in the testing matrix.

Documentation:
- Update README to reflect the latest Postgres version as 17-3.5.